### PR TITLE
Fixes bug where Projects weren't being displayed. Also adds Peer to peer

### DIFF
--- a/_projects/mealscount.md
+++ b/_projects/mealscount.md
@@ -3,8 +3,8 @@ layout: page
 title: Meals Count
 path: mealscount
 featured: yes
-partners: [California Food Policy Advocates](https://cfpa.net/), [San Diego Hunger Coalition](https://www.sandiegohungercoalition.org/)
-project leaders: [Nikolaj Baer](https://github.com/nikolajbaer/)
+partners: "[California Food Policy Advocates](https://cfpa.net/), [San Diego Hunger Coalition](https://www.sandiegohungercoalition.org/)"
+projectleaders: "[Nikolaj Baer](https://github.com/nikolajbaer/)"
 description: A web-based tool California school districts can use to optimize free meal program participation and federal reimbursement
 ---
 

--- a/_projects/mealscount.md
+++ b/_projects/mealscount.md
@@ -4,7 +4,7 @@ title: Meals Count
 path: mealscount
 featured: yes
 partners: "[California Food Policy Advocates](https://cfpa.net/), [San Diego Hunger Coalition](https://www.sandiegohungercoalition.org/)"
-projectleaders: "[Nikolaj Baer](https://github.com/nikolajbaer/)"
+project leaders: "[Nikolaj Baer](https://github.com/nikolajbaer/)"
 description: A web-based tool California school districts can use to optimize free meal program participation and federal reimbursement
 ---
 

--- a/_projects/peertopeer.md
+++ b/_projects/peertopeer.md
@@ -4,7 +4,7 @@ title: Peer to Peer Lending
 path: p2p-lending
 featured: yes
 partners: "[Linda Vista Library](https://www.sandiego.gov/public-library/locations/linda-vista-library)"
-projectleaders: "[Nikolaj Baer](https://github.com/nikolajbaer/), [Nick Engmann](https://github.com/NickEngmann/)"
+project leaders: "[Nikolaj Baer](https://github.com/nikolajbaer/), [Nick Engmann](https://github.com/NickEngmann/)"
 description: A web application to help the Linda Vista Library branch facilitate community peer-to-peer lending.
 ---
 

--- a/_projects/peertopeer.md
+++ b/_projects/peertopeer.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Peer to Peer Lending
+path: p2p-lending
+featured: yes
+partners: "[Linda Vista Library](https://www.sandiego.gov/public-library/locations/linda-vista-library)"
+projectleaders: "[Nikolaj Baer](https://github.com/nikolajbaer/), [Nick Engmann](https://github.com/NickEngmann/)"
+description: A web application to help the Linda Vista Library branch facilitate community peer-to-peer lending.
+---
+
+## Overview
+
+The goal is to help community members share books and media outside of the SD Library's collection (specifically foreign language books) with the help of the library. The Library staff will faciltate the loans with this application so that there is both trust and anonymity in the lending.
+
+### Links
+
+- [Github Project](https://github.com/opensandiego/p2p-lending)


### PR DESCRIPTION
Missing Quotation Marks on some YAML keys. Causes the Projects pages to be displayed improperly.
Also added Peer to Peer lending info

Before:
![image](https://user-images.githubusercontent.com/1075072/58194157-98536500-7c79-11e9-84ac-29719735edf0.png)

After:
![image](https://user-images.githubusercontent.com/1075072/58194167-9f7a7300-7c79-11e9-96eb-d5fd65abff47.png)

![bitmoji](https://render.bitstrips.com/v2/cpanel/359644fb-c5df-4412-9bc7-ae838696ef14-f35a46c4-b1dd-4da0-a9de-3b0fa0f211ba-v1.png?transparent=1&palette=1&width=246)

Issue #35 and #37