### PR TITLE
Update “Donate” page link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -40,7 +40,7 @@
       <i class="fa fa-university"></i>
       About
     </a>
-    <a target="_blank" class="p-2 text-dark" href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Open%20San%20Diego">
+    <a target="_blank" class="p-2 text-dark" href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Open%20San%20Diego&utm_source=OpenSanDiegoSite">
       <i class="fa fa-gift"></i>
       Donate 
     </a>


### PR DESCRIPTION
We at Code for America created this new donate page [seven months
ago][1] because the old donate page required a high maintenance
burden and created an unnecessary duplication in our process.

This commit updates your website to link to the new Donate page.

[1]: https://groups.google.com/a/codeforamerica.org/g/brigadeleads/c/At0loymFW0I/m/OVC-W90yEAAJ