### PR TITLE
Update broken slack link with new one

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -17,7 +17,7 @@ layout: base
       <a
         target="_blank"
         class="btn btn-primary"
-        href="https://osd-slack-auto-invite.herokuapp.com/"
+        href="https://join.slack.com/t/opensandiego/shared_invite/zt-1upphf5q8-I8QT3NPUFlPjDlOjs~tn5A"
         alt="Clicking this button will auto-invite you to join our Slack group where we organize ourselves."
       >
         <i class="fa fa-slack"></i> Chat with us on Slack


### PR DESCRIPTION
**Describe the changes in this Pull Request**
Slack link was broken on home page, updated with a new invite link that doesn't expire

**What issue(s) does this Pull Request resolve?**
No related issue